### PR TITLE
Api error handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "GPL-3.0",
   "scripts": {
     "start": "ng serve --host=0.0.0.0",
-    "check": "docker stack deploy -c docker-compose-api.yml docks-api;ng lint;ng build --prod; ng test",
+    "check": "ng lint;ng build --prod; ng test",
     "serve": "ng serve --aot",
     "fix": "ng lint --fix",
     "build": "ng build --prod --no-progress",

--- a/src/app/models/service/mode/mode.model.ts
+++ b/src/app/models/service/mode/mode.model.ts
@@ -8,5 +8,5 @@ export interface Mode {
     Replicas: number;
   };
 
-  Global?: { };
+  Global?: {};
 }

--- a/src/app/pages/home/home.component.ts
+++ b/src/app/pages/home/home.component.ts
@@ -66,48 +66,54 @@ export class HomeComponent implements OnInit {
   }
 
   getStats() {
-    this.volumeService.getVolumes().subscribe((volume) => {
-      for (let i = 0; i < volume.length; i++) {
-        this.volumes.push(volume[i]);
-      }
-      this.numVol = this.volumes.length;
-    },
-  (err) => {
-    console.error(err);
-  });
-
-    this.networkService.getNetworks().subscribe((network) => {
-      for (let i = 0; i < network.length; i++) {
-        this.networks.push(network[i]);
-      }
-      this.numNet = this.networks.length;
-    },
-  (err) => {
-    console.error(err);
-  });
-
-    this.taskService.getTasks().subscribe((task) => {
-      for (let i = 0; i < task.length; i++) {
-        this.tasks.push(task[i]);
-
-        console.log(task[i].Status.State);
-
-        if (task[i].Status.State === 'running') {
-          this.runTask++;
+    this.volumeService.getVolumes().subscribe(
+      (volume) => {
+        for (let i = 0; i < volume.length; i++) {
+          this.volumes.push(volume[i]);
         }
-
-        if (task[i].Status.State === 'shutdown') {
-          this.stopTask++;
-        }
-
-        if (task[i].Status.State === 'failed') {
-          this.pauseTask++;
-        }
+        this.numVol = this.volumes.length;
+      },
+      (err) => {
+        console.error(err);
       }
-      this.numTask = this.tasks.length;
-    },
-    (err) => {
-  console.error(err);
-    });
+    );
+
+    this.networkService.getNetworks().subscribe(
+      (network) => {
+        for (let i = 0; i < network.length; i++) {
+          this.networks.push(network[i]);
+        }
+        this.numNet = this.networks.length;
+      },
+      (err) => {
+        console.error(err);
+      }
+    );
+
+    this.taskService.getTasks().subscribe(
+      (task) => {
+        for (let i = 0; i < task.length; i++) {
+          this.tasks.push(task[i]);
+
+          console.log(task[i].Status.State);
+
+          if (task[i].Status.State === 'running') {
+            this.runTask++;
+          }
+
+          if (task[i].Status.State === 'shutdown') {
+            this.stopTask++;
+          }
+
+          if (task[i].Status.State === 'failed') {
+            this.pauseTask++;
+          }
+        }
+        this.numTask = this.tasks.length;
+      },
+      (err) => {
+        console.error(err);
+      }
+    );
   }
 }

--- a/src/app/pages/services/list-view/service-list-view.component.ts
+++ b/src/app/pages/services/list-view/service-list-view.component.ts
@@ -28,16 +28,16 @@ export class ServiceListViewComponent implements OnInit {
   public temp = [];
   public rows: any[] = [];
   public columns: any = [
-      {prop: 'Name'},
-      {prop: 'ID'},
-      {prop: 'Stack'},
-      {prop: 'Image'},
-      {prop: 'Mode'},
-      {prop: 'Replicas'},
-      {prop: 'Ports'},
-      {prop: 'CreatedAt'},
-      {prop: 'UpdatedAt'},
-      {prop: 'Ownership'}
+    { prop: 'Name' },
+    { prop: 'ID' },
+    { prop: 'Stack' },
+    { prop: 'Image' },
+    { prop: 'Mode' },
+    { prop: 'Replicas' },
+    { prop: 'Ports' },
+    { prop: 'CreatedAt' },
+    { prop: 'UpdatedAt' },
+    { prop: 'Ownership' },
   ];
 
   public selected = [];

--- a/src/app/pages/services/operations/services-operations.component.ts
+++ b/src/app/pages/services/operations/services-operations.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { ServiceSpec } from '../../../models/service/spec/spec.model';
+import { Service } from '../../../models/service/service.model';
 import { ServicesService } from '../../../services/services/services.service';
 import { MockService } from '../../../services/mock/mock.service';
 
@@ -10,7 +11,7 @@ import { MockService } from '../../../services/mock/mock.service';
   styleUrls: ['./services-operations.component.css'],
 })
 export class ServicesOperationsComponent implements OnInit {
-  public spec: ServiceSpec = null;
+  public serv: Service = null;
   public serviceLog: String;
   public allDataFetched = false;
   public currentJustify = 'justified';
@@ -23,7 +24,7 @@ export class ServicesOperationsComponent implements OnInit {
   ngOnInit() {
     this.route.params.subscribe((res) => {
       this.serviceService.inspectService(res.id).subscribe((serv) => {
-        this.spec = serv;
+        this.serv = serv;
         this.serviceService.getServiceLog(res.id).subscribe((log) => {
           this.serviceLog = log;
           this.allDataFetched = true;

--- a/src/app/pages/stacks/stack-edit/stack-edit.component.ts
+++ b/src/app/pages/stacks/stack-edit/stack-edit.component.ts
@@ -4,7 +4,7 @@ import { Router, ActivatedRoute, ParamMap } from '@angular/router';
 import {
   StackService,
   StackError,
-  StackResult,
+  StackErrorCode,
 } from 'services/stack/stack.service';
 
 @Component({
@@ -68,10 +68,10 @@ export class StackEditComponent implements OnInit {
             { updatedStack: this.stackModel.stackName },
           ]);
         },
-        (err: StackResult) => {
+        (err: StackError) => {
           console.error(err);
           this.clearAlerts();
-          if (err.code === StackError.ERR_STACK_NAME_TAKEN) {
+          if (err.code === StackErrorCode.ERR_STACK_NAME_TAKEN) {
             this.alreadyExists = true;
             this.badUser = this.stackModel.stackName;
           } else {

--- a/src/app/pages/stacks/stacks-create/stacks-create.component.ts
+++ b/src/app/pages/stacks/stacks-create/stacks-create.component.ts
@@ -4,7 +4,7 @@ import { Router } from '@angular/router';
 import {
   StackService,
   StackError,
-  StackResult,
+  StackErrorCode,
 } from 'services/stack/stack.service';
 
 @Component({
@@ -54,7 +54,7 @@ export class StacksCreateComponent implements OnInit {
     this.stackService
       .deployStack(this.stackModel.stackName, btoa(this.stackModel.stackFile))
       .subscribe(
-        (result: StackResult) => {
+        (result: StackError) => {
           this.clearAlerts();
           this.submitted = false;
           this.router.navigate([
@@ -62,10 +62,10 @@ export class StacksCreateComponent implements OnInit {
             { createdStack: this.stackModel.stackName },
           ]);
         },
-        (err: StackResult) => {
+        (err: StackError) => {
           console.error(err);
           this.clearAlerts();
-          if (err.code === StackError.ERR_STACK_NAME_TAKEN) {
+          if (err.code === StackErrorCode.ERR_STACK_NAME_TAKEN) {
             this.alreadyExists = true;
             this.badUser = this.stackModel.stackName;
           } else {

--- a/src/app/pages/stacks/stacks-view/stacks-view.component.ts
+++ b/src/app/pages/stacks/stacks-view/stacks-view.component.ts
@@ -1,6 +1,10 @@
 import { Component, OnInit } from '@angular/core';
 import { Stack } from 'app/models/stack/stack.model';
-import { StackService, StackError, StackErrorCode } from 'services/stack/stack.service';
+import {
+  StackService,
+  StackError,
+  StackErrorCode,
+} from 'services/stack/stack.service';
 import { ActivatedRoute, ParamMap } from '@angular/router';
 import { NgbModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 

--- a/src/app/pages/stacks/stacks-view/stacks-view.component.ts
+++ b/src/app/pages/stacks/stacks-view/stacks-view.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { Stack } from 'app/models/stack/stack.model';
-import { StackService, StackError } from 'services/stack/stack.service';
+import { StackService, StackError, StackErrorCode } from 'services/stack/stack.service';
 import { ActivatedRoute, ParamMap } from '@angular/router';
 import { NgbModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 
@@ -85,7 +85,7 @@ export class StacksViewComponent implements OnInit {
     this.stackService.removeStack(this.stackNameToDelete).subscribe(
       (result: StackError) => {
         this.clearAlerts();
-        if (result === StackError.ERR_OK) {
+        if (result.code === StackErrorCode.ERR_OK) {
           this.deletedStack = this.stackNameToDelete;
         } else {
           this.genericError = true;
@@ -96,7 +96,7 @@ export class StacksViewComponent implements OnInit {
       },
       (err: StackError) => {
         this.clearAlerts();
-        if (err === StackError.ERR_STACK_MISSING) {
+        if (err.code === StackErrorCode.ERR_STACK_MISSING) {
           this.stackNotFoundError = this.stackNameToDelete;
         } else {
           this.genericError = true;

--- a/src/app/pages/user-management/user-create/user-create.component.ts
+++ b/src/app/pages/user-management/user-create/user-create.component.ts
@@ -3,7 +3,7 @@ import { Router } from '@angular/router';
 
 import {
   UserService,
-  UserStatusCode,
+  UserErrorCode,
   UserError,
 } from '../../../services/user-management/user.service';
 import { User } from '../../../models/user-management/user.model';
@@ -52,7 +52,7 @@ export class UserCreateComponent implements OnInit {
         },
         (err: UserError) => {
           console.error(err);
-          if (err.code === UserStatusCode.CREATE_ERR_EXISTS) {
+          if (err.code === UserErrorCode.CREATE_ERR_EXISTS) {
             this.alreadyExists = true;
             this.badUser = this.model.username;
           } else {

--- a/src/app/pages/user-management/user-create/user-create.component.ts
+++ b/src/app/pages/user-management/user-create/user-create.component.ts
@@ -3,7 +3,7 @@ import { Router } from '@angular/router';
 
 import {
   UserService,
-  CreateUserStatus,
+  UserStatusCode,
 } from '../../../services/user-management/user.service';
 import { User } from '../../../models/user-management/user.model';
 
@@ -42,16 +42,16 @@ export class UserCreateComponent implements OnInit {
     this.userService
       .createUser(this.model.username, this.model.password)
       .subscribe(
-        (result: CreateUserStatus) => {
+        (result: UserStatusCode) => {
           this.submitted = false;
           this.router.navigate([
             '/users',
             { createdUser: this.model.username },
           ]);
         },
-        (err: CreateUserStatus) => {
+        (err: UserStatusCode) => {
           console.error(err);
-          if (err === CreateUserStatus.CREATE_ERR_EXISTS) {
+          if (err === UserStatusCode.CREATE_ERR_EXISTS) {
             this.alreadyExists = true;
             this.badUser = this.model.username;
           } else {

--- a/src/app/pages/user-management/user-create/user-create.component.ts
+++ b/src/app/pages/user-management/user-create/user-create.component.ts
@@ -4,6 +4,7 @@ import { Router } from '@angular/router';
 import {
   UserService,
   UserStatusCode,
+  UserError,
 } from '../../../services/user-management/user.service';
 import { User } from '../../../models/user-management/user.model';
 
@@ -49,9 +50,9 @@ export class UserCreateComponent implements OnInit {
             { createdUser: this.model.username },
           ]);
         },
-        (err: UserStatusCode) => {
+        (err: UserError) => {
           console.error(err);
-          if (err === UserStatusCode.CREATE_ERR_EXISTS) {
+          if (err.code === UserStatusCode.CREATE_ERR_EXISTS) {
             this.alreadyExists = true;
             this.badUser = this.model.username;
           } else {

--- a/src/app/pages/user-management/user-create/user-create.component.ts
+++ b/src/app/pages/user-management/user-create/user-create.component.ts
@@ -43,7 +43,7 @@ export class UserCreateComponent implements OnInit {
     this.userService
       .createUser(this.model.username, this.model.password)
       .subscribe(
-        (result: UserStatusCode) => {
+        (result: UserError) => {
           this.submitted = false;
           this.router.navigate([
             '/users',

--- a/src/app/pages/user-management/user-edit/user-edit.component.ts
+++ b/src/app/pages/user-management/user-edit/user-edit.component.ts
@@ -10,7 +10,7 @@ import { ActivatedRoute, ParamMap, Router } from '@angular/router';
 
 import {
   UserService,
-  UpdateUserStatus,
+  UserStatusCode,
 } from '../../../services/user-management/user.service';
 import { User } from '../../../models/user-management/user.model';
 
@@ -68,7 +68,7 @@ export class UserEditComponent implements OnInit {
       },
       (err) => {
         this.submitted = false;
-        if (err === UpdateUserStatus.UPDATE_ERR_NOT_FOUND) {
+        if (err === UserStatusCode.REQUEST_ERR_NOT_FOUND) {
           this.router.navigate([
             '/users',
             { updatedUserNotFound: user.username },

--- a/src/app/pages/user-management/user-edit/user-edit.component.ts
+++ b/src/app/pages/user-management/user-edit/user-edit.component.ts
@@ -10,7 +10,7 @@ import { ActivatedRoute, ParamMap, Router } from '@angular/router';
 
 import {
   UserService,
-  UserStatusCode,
+  UserErrorCode,
 } from '../../../services/user-management/user.service';
 import { User } from '../../../models/user-management/user.model';
 
@@ -68,7 +68,7 @@ export class UserEditComponent implements OnInit {
       },
       (err) => {
         this.submitted = false;
-        if (err === UserStatusCode.REQUEST_ERR_NOT_FOUND) {
+        if (err === UserErrorCode.REQUEST_ERR_NOT_FOUND) {
           this.router.navigate([
             '/users',
             { updatedUserNotFound: user.username },

--- a/src/app/pages/user-management/user-list/user-list.component.ts
+++ b/src/app/pages/user-management/user-list/user-list.component.ts
@@ -4,7 +4,7 @@ import { NgbModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 
 import {
   UserService,
-  UserStatusCode,
+  UserErrorCode,
 } from '../../../services/user-management/user.service';
 import { User } from '../../../models/user-management/user.model';
 
@@ -82,9 +82,9 @@ export class UserListComponent implements OnInit {
 
   deleteUser(username: string) {
     this.userService.deleteUser(username).subscribe(
-      (result: UserStatusCode) => {
+      (result: UserErrorCode) => {
         this.clearAlerts();
-        if (result === UserStatusCode.REQUEST_OK) {
+        if (result === UserErrorCode.REQUEST_OK) {
           this.deletedUser = username;
         } else {
           this.genericError = true;
@@ -93,9 +93,9 @@ export class UserListComponent implements OnInit {
         this.activeModal.close();
         this.fetchUsers();
       },
-      (err: UserStatusCode) => {
+      (err: UserErrorCode) => {
         this.clearAlerts();
-        if (err === UserStatusCode.REQUEST_ERR_NOT_FOUND) {
+        if (err === UserErrorCode.REQUEST_ERR_NOT_FOUND) {
           this.deletedUserNotFound = username;
         } else {
           this.genericError = true;

--- a/src/app/pages/user-management/user-list/user-list.component.ts
+++ b/src/app/pages/user-management/user-list/user-list.component.ts
@@ -4,7 +4,7 @@ import { NgbModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 
 import {
   UserService,
-  DeleteUserStatus,
+  UserStatusCode,
 } from '../../../services/user-management/user.service';
 import { User } from '../../../models/user-management/user.model';
 
@@ -82,9 +82,9 @@ export class UserListComponent implements OnInit {
 
   deleteUser(username: string) {
     this.userService.deleteUser(username).subscribe(
-      (result: DeleteUserStatus) => {
+      (result: UserStatusCode) => {
         this.clearAlerts();
-        if (result === DeleteUserStatus.DELETE_OK) {
+        if (result === UserStatusCode.REQUEST_OK) {
           this.deletedUser = username;
         } else {
           this.genericError = true;
@@ -93,9 +93,9 @@ export class UserListComponent implements OnInit {
         this.activeModal.close();
         this.fetchUsers();
       },
-      (err: DeleteUserStatus) => {
+      (err: UserStatusCode) => {
         this.clearAlerts();
-        if (err === DeleteUserStatus.DELETE_ERR_NOT_FOUND) {
+        if (err === UserStatusCode.REQUEST_ERR_NOT_FOUND) {
           this.deletedUserNotFound = username;
         } else {
           this.genericError = true;

--- a/src/app/pages/volumes/volumes-create/volumes-create.component.ts
+++ b/src/app/pages/volumes/volumes-create/volumes-create.component.ts
@@ -138,7 +138,7 @@ export class VolumesCreateComponent implements OnInit {
         this.clearAlerts();
         this.warning = true;
         this.submitted = false;
-        this.warningMessage = err.ErrorMessage;
+        this.warningMessage = err.message;
       }
     );
   }

--- a/src/app/pages/volumes/volumes-create/volumes-create.component.ts
+++ b/src/app/pages/volumes/volumes-create/volumes-create.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { Volume } from 'app/models/volume/volume.model';
 import { Router } from '@angular/router';
-import { VolumeService } from 'services/volume/volume.service';
+import { VolumeService, VolumeError } from 'services/volume/volume.service';
 import { FormBuilder } from '@angular/forms';
 import { Validators } from '@angular/forms';
 import { FormArray } from '@angular/forms';
@@ -14,7 +14,6 @@ import { debug } from 'util';
   styleUrls: ['./volumes-create.component.css'],
 })
 export class VolumesCreateComponent implements OnInit {
-
   public volumeModel: Volume;
   public alreadyExists = false;
   public genericError = false;
@@ -22,8 +21,9 @@ export class VolumesCreateComponent implements OnInit {
   public warning = false;
   public fileText = '';
   public badUser = '';
-  public warningMessage = 'There was a problem while creating the volume. No new volume created.' +
-  'Ensure type is correct and name contains no special characters';
+  public warningMessage =
+    'There was a problem while creating the volume. No new volume created.' +
+    'Ensure type is correct and name contains no special characters';
   // TODO: Paul Wood allow an unknown number of Options to be added dynamically, achieved using the formBuilder
 
   volumeForm: FormGroup = this.fb.group({
@@ -34,41 +34,48 @@ export class VolumesCreateComponent implements OnInit {
     ]),
     Labels: this.fb.array([
       // this.initLabels();
-    ])
+    ]),
   });
-
 
   initLabels() {
     return this.fb.group({
       Name: ['', Validators.required],
-      Value: ['']
+      Value: [''],
     });
   }
 
   initOptions() {
     return this.fb.group({
       OptionName: ['', Validators.required],
-      Value: ['']
+      Value: [''],
     });
   }
 
-  constructor(private router: Router, private volumeService: VolumeService, private fb: FormBuilder) {
+  constructor(
+    private router: Router,
+    private volumeService: VolumeService,
+    private fb: FormBuilder
+  ) {
     this.volumeModel = {
       Name: '',
       Driver: '',
     };
   }
 
-  ngOnInit() {
-  }
+  ngOnInit() {}
 
   convertOptions() {
     let i = 0;
     let temp = '{';
 
     while (i < this.Options.length) {
-        temp += '"' +  this.Options.at(i).get('OptionName').value + '":"' + this.Options.at(i).get('Value').value + '",';
-        i++;
+      temp +=
+        '"' +
+        this.Options.at(i).get('OptionName').value +
+        '":"' +
+        this.Options.at(i).get('Value').value +
+        '",';
+      i++;
     }
 
     // console.log(JSON.stringify(this.Options));
@@ -86,8 +93,13 @@ export class VolumesCreateComponent implements OnInit {
     let temp = '{';
 
     while (i < this.Labels.length) {
-        temp += '"' +  this.Labels.at(i).get('Name').value + '":"' + this.Labels.at(i).get('Value').value + '",';
-        i++;
+      temp +=
+        '"' +
+        this.Labels.at(i).get('Name').value +
+        '":"' +
+        this.Labels.at(i).get('Value').value +
+        '",';
+      i++;
     }
 
     // console.log(JSON.stringify(this.Options));
@@ -99,7 +111,6 @@ export class VolumesCreateComponent implements OnInit {
 
     return temp;
   }
-
 
   submit() {
     this.submitted = true;
@@ -114,24 +125,22 @@ export class VolumesCreateComponent implements OnInit {
     string = this.convertLabels();
     this.volumeModel.Labels = JSON.parse(string);
 
-    this.volumeService
-      .createVolume(this.volumeModel)
-      .subscribe(
-        (result: Volume) => {
-          this.clearAlerts();
-          this.submitted = false;
-          this.router.navigate([
-            '/volumes',
-            { createdVolume: this.volumeForm.get('Name').value },
-          ]);
-        },
-        (err: any) => {
-          console.error(err);
-          this.clearAlerts();
-            this.warning = true;
-            this.submitted = false;
-        }
-      );
+    this.volumeService.createVolume(this.volumeModel).subscribe(
+      (result: Volume) => {
+        this.clearAlerts();
+        this.submitted = false;
+        this.router.navigate([
+          '/volumes',
+          { createdVolume: this.volumeForm.get('Name').value },
+        ]);
+      },
+      (err: VolumeError) => {
+        this.clearAlerts();
+        this.warning = true;
+        this.submitted = false;
+        this.warningMessage = err.ErrorMessage;
+      }
+    );
   }
 
   clearAlerts() {
@@ -174,5 +183,3 @@ export class VolumesCreateComponent implements OnInit {
     return this.volumeForm.get('Labels') as FormArray;
   }
 }
-
-

--- a/src/app/pages/volumes/volumes-view/volumes-view.component.spec.ts
+++ b/src/app/pages/volumes/volumes-view/volumes-view.component.spec.ts
@@ -24,7 +24,7 @@ describe('VolumesViewComponent', () => {
         RouterTestingModule,
         FormsModule,
         NgxDatatableModule,
-        SpinnerModule
+        SpinnerModule,
       ],
       providers: [
         VolumeService,

--- a/src/app/pages/volumes/volumes-view/volumes-view.component.ts
+++ b/src/app/pages/volumes/volumes-view/volumes-view.component.ts
@@ -6,10 +6,9 @@ import { ActivatedRoute, ParamMap } from '@angular/router';
 @Component({
   selector: 'app-volumes-view',
   templateUrl: './volumes-view.component.html',
-  styleUrls: ['./volumes-view.component.css']
+  styleUrls: ['./volumes-view.component.css'],
 })
 export class VolumesViewComponent implements OnInit {
-
   public volumes: Volume[];
   public searchString = [];
   public createdVolume = '';
@@ -20,18 +19,17 @@ export class VolumesViewComponent implements OnInit {
 
   constructor(
     private volumeService: VolumeService,
-    private route: ActivatedRoute,
-    ) {
-      this.route.paramMap.subscribe((params: ParamMap) => {
-        if (params.has('createdVolume')) {
-          this.createdVolume = params.get('createdVolume');
-        }
-      });
-    }
+    private route: ActivatedRoute
+  ) {
+    this.route.paramMap.subscribe((params: ParamMap) => {
+      if (params.has('createdVolume')) {
+        this.createdVolume = params.get('createdVolume');
+      }
+    });
+  }
 
   ngOnInit() {
     this.fetchVolumes();
-
   }
 
   clearAlerts() {

--- a/src/app/pages/volumes/volumes.module.ts
+++ b/src/app/pages/volumes/volumes.module.ts
@@ -8,14 +8,20 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { VolumesCreateComponent } from './volumes-create/volumes-create.component';
 import { VolumesViewComponent } from './volumes-view/volumes-view.component';
 
-
 import { VolumesRoutingModule } from './volumes.routing-module';
 import { SpinnerModule } from 'app/shared/spinner/spinner.module';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 
 @NgModule({
-  imports: [CommonModule, FormsModule, ReactiveFormsModule, VolumesRoutingModule,
-  SpinnerModule, NgbModule, NgxDatatableModule],
+  imports: [
+    CommonModule,
+    FormsModule,
+    ReactiveFormsModule,
+    VolumesRoutingModule,
+    SpinnerModule,
+    NgbModule,
+    NgxDatatableModule,
+  ],
   declarations: [VolumesCreateComponent, VolumesViewComponent],
   providers: [VolumeService],
 })

--- a/src/app/pages/volumes/volumes.routing-module.ts
+++ b/src/app/pages/volumes/volumes.routing-module.ts
@@ -3,8 +3,6 @@ import { Routes, RouterModule } from '@angular/router';
 import { VolumesViewComponent } from 'pages/volumes/volumes-view/volumes-view.component';
 import { VolumesCreateComponent } from 'pages/volumes/volumes-create/volumes-create.component';
 
-
-
 const routes: Routes = [
   {
     path: '',
@@ -15,7 +13,7 @@ const routes: Routes = [
     path: 'create',
     pathMatch: 'full',
     component: VolumesCreateComponent,
-  }
+  },
 ];
 
 @NgModule({

--- a/src/app/services/auth/auth.service.spec.ts
+++ b/src/app/services/auth/auth.service.spec.ts
@@ -27,24 +27,4 @@ describe('AuthService', () => {
       expect(service.logout).toBeTruthy();
     }
   ));
-
-  it('should login', inject([AuthService], (service: AuthService) => {
-    service.getToken('admin', 'admin').subscribe(() => {
-      expect(service.isLoggedIn()).toEqual(true);
-    });
-  }));
-
-  it('should fail on invalid login', inject(
-    [AuthService],
-    (service: AuthService) => {
-      service.getToken('admin2', 'admin').subscribe(
-        () => {
-          // NOP
-        },
-        (err) => {
-          expect(err).toEqual(AuthError.AUTH_ERR_CREDENTIALS);
-        }
-      );
-    }
-  ));
 });

--- a/src/app/services/network/network.service.ts
+++ b/src/app/services/network/network.service.ts
@@ -16,12 +16,17 @@ import { ErrorObservable } from 'rxjs/observable/ErrorObservable';
 import { ConfigurationService } from '../configuration/configuration.service';
 import { Network } from 'app/models/network/network.model';
 
-enum NetworkError {
+enum NetworkErrorCode {
   ERR_OK = 200,
   ERR_SERVER = 500,
   ERR_NO_NETWORK = 404,
   ERR_NO_OP = 403,
   ERR_STREAM = 101,
+}
+
+export interface NetworkError {
+  code: NetworkErrorCode;
+  message: string;
 }
 
 @Injectable()
@@ -41,7 +46,10 @@ export class NetworkService {
           return <Network>x;
         }),
         catchError((err: HttpErrorResponse) => {
-          return ErrorObservable.create(<NetworkError>err.status);
+          return ErrorObservable.create({
+            code: <NetworkErrorCode>err.status,
+            message: err.error['message'],
+          });
         })
       );
   }
@@ -78,7 +86,10 @@ export class NetworkService {
           return <Network>x;
         }),
         catchError((err: HttpErrorResponse) => {
-          return ErrorObservable.create(<NetworkError>err.status);
+          return ErrorObservable.create({
+            code: <NetworkErrorCode>err.status,
+            message: err.error['message'],
+          });
         })
       );
   }
@@ -107,7 +118,10 @@ export class NetworkService {
           return <Network>x;
         }),
         catchError((err: HttpErrorResponse) => {
-          return ErrorObservable.create(<NetworkError>err.status);
+          return ErrorObservable.create({
+            code: <NetworkErrorCode>err.status,
+            message: err.error['message'],
+          });
         })
       );
   }
@@ -128,7 +142,10 @@ export class NetworkService {
           return x;
         }),
         catchError((err: HttpErrorResponse) => {
-          return ErrorObservable.create(<NetworkError>err.status);
+          return ErrorObservable.create({
+            code: <NetworkErrorCode>err.status,
+            message: err.error['message'],
+          });
         })
       );
   }
@@ -161,7 +178,10 @@ export class NetworkService {
           return x;
         }),
         catchError((err: HttpErrorResponse) => {
-          return ErrorObservable.create(<NetworkError>err.status);
+          return ErrorObservable.create({
+            code: <NetworkErrorCode>err.status,
+            message: err.error['message'],
+          });
         })
       );
   }
@@ -196,7 +216,10 @@ export class NetworkService {
           return x;
         }),
         catchError((err: HttpErrorResponse) => {
-          return ErrorObservable.create(<NetworkError>err.status);
+          return ErrorObservable.create({
+            code: <NetworkErrorCode>err.status,
+            message: err.error['message'],
+          });
         })
       );
   }
@@ -216,7 +239,10 @@ export class NetworkService {
           return x;
         }),
         catchError((err: HttpErrorResponse) => {
-          return ErrorObservable.create(<NetworkError>err.status);
+          return ErrorObservable.create({
+            code: <NetworkErrorCode>err.status,
+            message: err.error['message'],
+          });
         })
       );
   }

--- a/src/app/services/services/services.service.ts
+++ b/src/app/services/services/services.service.ts
@@ -16,7 +16,7 @@ import { Service } from '../../models/service/service.model';
 import { ConfigurationService } from '../configuration/configuration.service';
 import { ServiceSpec } from '../../models/service/spec/spec.model';
 
-export enum ServiceErrorcode {
+export enum ServiceErrorCode {
   ERR_OK = 200,
   ERR_SERVER = 500,
   ERR_NODE_N_SWARM = 503,
@@ -29,7 +29,7 @@ export enum ServiceErrorcode {
 }
 
 export interface ServiceError {
-  code: ServiceErrorcode;
+  code: ServiceErrorCode;
   message: string;
 }
 
@@ -53,7 +53,7 @@ export class ServicesService {
         }),
         catchError((err: HttpErrorResponse) => {
           return ErrorObservable.create({
-            code: <ServiceErrorcode>err.status,
+            code: <ServiceErrorCode>err.status,
             message: err.error['message'],
           });
         })
@@ -64,20 +64,20 @@ export class ServicesService {
    * Returns more detailed information about a particular service.
    *
    * @param {string} id
-   * @returns {Observable<ServiceSpec>}
+   * @returns {Observable<Service>}
    */
-  public inspectService(id: string): Observable<ServiceSpec> {
+  public inspectService(id: string): Observable<Service> {
     return this.http
       .get<JSON>(this.config.getAPIHostname() + '/docker/services/' + id, {
         responseType: 'json',
       })
       .pipe(
         map((x) => {
-          return x['Spec'];
+          return x;
         }),
         catchError((err: HttpErrorResponse) => {
           return ErrorObservable.create({
-            code: <ServiceErrorcode>err.status,
+            code: <ServiceErrorCode>err.status,
             message: err.error['message'],
           });
         })
@@ -101,7 +101,7 @@ export class ServicesService {
         }),
         catchError((err: HttpErrorResponse) => {
           return ErrorObservable.create({
-            code: <ServiceErrorcode>err.status,
+            code: <ServiceErrorCode>err.status,
             message: err.error['message'],
           });
         })
@@ -128,7 +128,7 @@ export class ServicesService {
         }),
         catchError((err: HttpErrorResponse) => {
           return ErrorObservable.create({
-            code: <ServiceErrorcode>err.status,
+            code: <ServiceErrorCode>err.status,
             message: err.error['message'],
           });
         })
@@ -155,7 +155,7 @@ export class ServicesService {
         }),
         catchError((err: HttpErrorResponse) => {
           return ErrorObservable.create({
-            code: <ServiceErrorcode>err.status,
+            code: <ServiceErrorCode>err.status,
             message: err.error['message'],
           });
         })
@@ -172,13 +172,13 @@ export class ServicesService {
    */
   public scaleService(id: string, replicas: number): Observable<string> {
     return this.inspectService(id).pipe(
-      map((spec: ServiceSpec) => {
-        spec.Mode.Replicated.Replicas = replicas;
-        return this.updateService(id, spec);
+      map((serv: Service) => {
+        serv.Spec.Mode.Replicated.Replicas = replicas;
+        return this.updateService(id, serv.Spec);
       }),
       catchError((err: HttpErrorResponse) => {
         return ErrorObservable.create({
-          code: <ServiceErrorcode>err.status,
+          code: <ServiceErrorCode>err.status,
           message: err.error['message'],
         });
       })
@@ -206,12 +206,12 @@ export class ServicesService {
               return data;
             })
             .catch(() => {
-              return ServiceErrorcode.ERR_UNKNOWN;
+              return ServiceErrorCode.ERR_UNKNOWN;
             });
         }),
         catchError((err: HttpErrorResponse) => {
           return ErrorObservable.create({
-            code: <ServiceErrorcode>err.status,
+            code: <ServiceErrorCode>err.status,
             message: err.error['message'],
           });
         })

--- a/src/app/services/services/services.service.ts
+++ b/src/app/services/services/services.service.ts
@@ -16,7 +16,7 @@ import { Service } from '../../models/service/service.model';
 import { ConfigurationService } from '../configuration/configuration.service';
 import { ServiceSpec } from '../../models/service/spec/spec.model';
 
-export enum ServiceError {
+export enum ServiceErrorcode {
   ERR_OK = 200,
   ERR_SERVER = 500,
   ERR_NODE_N_SWARM = 503,
@@ -26,6 +26,11 @@ export enum ServiceError {
   ERR_NO_SERVICE = 404,
   ERR_STREAM = 101,
   ERR_UNKNOWN,
+}
+
+export interface ServiceError {
+  code: ServiceErrorcode;
+  message: string;
 }
 
 @Injectable()
@@ -47,7 +52,10 @@ export class ServicesService {
           return <Services[]>data;
         }),
         catchError((err: HttpErrorResponse) => {
-          return ErrorObservable.create(<ServiceError>err.status);
+          return ErrorObservable.create({
+            code: <ServiceErrorcode>err.status,
+            message: err.error['message'],
+          });
         })
       );
   }
@@ -68,7 +76,10 @@ export class ServicesService {
           return x['Spec'];
         }),
         catchError((err: HttpErrorResponse) => {
-          return ErrorObservable.create(<ServiceError>err.status);
+          return ErrorObservable.create({
+            code: <ServiceErrorcode>err.status,
+            message: err.error['message'],
+          });
         })
       );
   }
@@ -89,7 +100,10 @@ export class ServicesService {
           return x;
         }),
         catchError((err: HttpErrorResponse) => {
-          return ErrorObservable.create(<ServiceError>err.status);
+          return ErrorObservable.create({
+            code: <ServiceErrorcode>err.status,
+            message: err.error['message'],
+          });
         })
       );
   }
@@ -113,7 +127,10 @@ export class ServicesService {
           return x;
         }),
         catchError((err: HttpErrorResponse) => {
-          return ErrorObservable.create(<ServiceError>err.status);
+          return ErrorObservable.create({
+            code: <ServiceErrorcode>err.status,
+            message: err.error['message'],
+          });
         })
       );
   }
@@ -137,7 +154,10 @@ export class ServicesService {
           return x;
         }),
         catchError((err: HttpErrorResponse) => {
-          return ErrorObservable.create(<ServiceError>err.status);
+          return ErrorObservable.create({
+            code: <ServiceErrorcode>err.status,
+            message: err.error['message'],
+          });
         })
       );
   }
@@ -157,7 +177,10 @@ export class ServicesService {
         return this.updateService(id, spec);
       }),
       catchError((err: HttpErrorResponse) => {
-        return ErrorObservable.create(<ServiceError>err.status);
+        return ErrorObservable.create({
+          code: <ServiceErrorcode>err.status,
+          message: err.error['message'],
+        });
       })
     );
   }
@@ -183,11 +206,14 @@ export class ServicesService {
               return data;
             })
             .catch(() => {
-              return ServiceError.ERR_UNKNOWN;
+              return ServiceErrorcode.ERR_UNKNOWN;
             });
         }),
         catchError((err: HttpErrorResponse) => {
-          return ErrorObservable.create(<ServiceError>err.status);
+          return ErrorObservable.create({
+            code: <ServiceErrorcode>err.status,
+            message: err.error['message'],
+          });
         })
       );
   }

--- a/src/app/services/stack/stack.service.ts
+++ b/src/app/services/stack/stack.service.ts
@@ -63,13 +63,13 @@ export class StackService {
         map((x) => {
           return {
             code: StackErrorCode.ERR_OK,
-            message: x,
+            message: 'Stack deployed!',
           };
         }),
         catchError((err: HttpErrorResponse) => {
           return ErrorObservable.create({
             code: <StackErrorCode>err.status,
-            message: err.error,
+            message: err.error['message'],
           });
         })
       );
@@ -140,13 +140,13 @@ export class StackService {
         map((x) => {
           return {
             code: StackErrorCode.ERR_OK,
-            message: x,
+            message: 'Stack Updated',
           };
         }),
         catchError((err: HttpErrorResponse) => {
           return ErrorObservable.create({
             code: <StackErrorCode>err.status,
-            message: err.error,
+            message: err.error['message'],
           });
         })
       );

--- a/src/app/services/stack/stack.service.ts
+++ b/src/app/services/stack/stack.service.ts
@@ -39,7 +39,7 @@ export class StackService {
         }),
         catchError((err: HttpErrorResponse) => {
           return ErrorObservable.create({
-            code: StackErrorCode.ERR_OK,
+            code: <StackErrorCode>err.status,
             message: err.error['message'],
           });
         })
@@ -92,7 +92,7 @@ export class StackService {
         }),
         catchError((err: HttpErrorResponse) => {
           return ErrorObservable.create({
-            code: StackErrorCode.ERR_OK,
+            code: <StackErrorCode>err.status,
             message: err.error['message'],
           });
         })
@@ -116,7 +116,7 @@ export class StackService {
         }),
         catchError((err: HttpErrorResponse) => {
           return ErrorObservable.create({
-            code: StackErrorCode.ERR_OK,
+            code: <StackErrorCode>err.status,
             message: err.error['message'],
           });
         })
@@ -168,7 +168,7 @@ export class StackService {
         }),
         catchError((err: HttpErrorResponse) => {
           return ErrorObservable.create({
-            code: StackErrorCode.ERR_OK,
+            code: <StackErrorCode>err.status,
             message: err.error['message'],
           });
         })

--- a/src/app/services/stack/stack.service.ts
+++ b/src/app/services/stack/stack.service.ts
@@ -7,20 +7,17 @@ import { Stack } from 'app/models/stack/stack.model';
 import { Observable } from 'rxjs/Observable';
 import { ConfigurationService } from 'services/configuration/configuration.service';
 
-export enum StackError {
+export enum StackErrorCode {
   ERR_OK = 200,
   ERR_STACK_NAME_TAKEN = 409,
   ERR_STACK_MISSING = 404, // sigh
 }
 
 // Compound structure
-export interface StackResult {
-  code: StackError;
+export interface StackError {
+  code: StackErrorCode;
   message: string;
 }
-
-// TODO(CDuPlooy): Add helper to encode file
-// TODO(CDuPlooy): Proper modelling of the returned tasks && services.
 
 @Injectable()
 export class StackService {
@@ -41,7 +38,10 @@ export class StackService {
           return <Stack[]>x['data'];
         }),
         catchError((err: HttpErrorResponse) => {
-          return ErrorObservable.create(<StackError>err.status);
+          return ErrorObservable.create({
+            code: StackErrorCode.ERR_OK,
+            message: err.error['message'],
+          });
         })
       );
   }
@@ -50,9 +50,9 @@ export class StackService {
    * Creates a new stack.
    *
    * Note that the _64params field is a base64 encoded file.
-   * @returns {Observable<StackResult>}
+   * @returns {Observable<StackError>}
    */
-  public deployStack(name: string, _64params: string): Observable<StackResult> {
+  public deployStack(name: string, _64params: string): Observable<StackError> {
     return this.http
       .post(
         this.config.getAPIHostname() + '/stacks',
@@ -62,13 +62,13 @@ export class StackService {
       .pipe(
         map((x) => {
           return {
-            code: StackError.ERR_OK,
+            code: StackErrorCode.ERR_OK,
             message: x,
           };
         }),
         catchError((err: HttpErrorResponse) => {
           return ErrorObservable.create({
-            code: <StackError>err.status,
+            code: <StackErrorCode>err.status,
             message: err.error,
           });
         })
@@ -91,7 +91,10 @@ export class StackService {
           return x;
         }),
         catchError((err: HttpErrorResponse) => {
-          return ErrorObservable.create(<StackError>err.status);
+          return ErrorObservable.create({
+            code: StackErrorCode.ERR_OK,
+            message: err.error['message'],
+          });
         })
       );
   }
@@ -112,7 +115,10 @@ export class StackService {
           return x;
         }),
         catchError((err: HttpErrorResponse) => {
-          return ErrorObservable.create(<StackError>err.status);
+          return ErrorObservable.create({
+            code: StackErrorCode.ERR_OK,
+            message: err.error['message'],
+          });
         })
       );
   }
@@ -121,9 +127,9 @@ export class StackService {
    * Updates an existing stack.
    *
    * Note that the _64params field is a base64 encoded file.
-   * @returns {Observable<StackResult>}
+   * @returns {Observable<StackError>}
    */
-  public updateStack(name: string, _64params: string): Observable<StackResult> {
+  public updateStack(name: string, _64params: string): Observable<StackError> {
     return this.http
       .put(
         this.config.getAPIHostname() + '/stacks/' + name,
@@ -133,13 +139,13 @@ export class StackService {
       .pipe(
         map((x) => {
           return {
-            code: StackError.ERR_OK,
+            code: StackErrorCode.ERR_OK,
             message: x,
           };
         }),
         catchError((err: HttpErrorResponse) => {
           return ErrorObservable.create({
-            code: <StackError>err.status,
+            code: <StackErrorCode>err.status,
             message: err.error,
           });
         })
@@ -158,10 +164,13 @@ export class StackService {
       })
       .pipe(
         map((x) => {
-          return StackError.ERR_OK;
+          return StackErrorCode.ERR_OK;
         }),
         catchError((err: HttpErrorResponse) => {
-          return ErrorObservable.create(<StackError>err.status);
+          return ErrorObservable.create({
+            code: StackErrorCode.ERR_OK,
+            message: err.error['message'],
+          });
         })
       );
   }

--- a/src/app/services/task/task.service.ts
+++ b/src/app/services/task/task.service.ts
@@ -13,11 +13,16 @@ import { Task } from '../../models/task/task.model';
 import { ErrorObservable } from 'rxjs/observable/ErrorObservable';
 import { ConfigurationService } from '../configuration/configuration.service';
 
-export enum TaskError {
+export enum TaskErrorCode {
   ERR_OK = 200,
   ERR_SERVER = 500,
   ERR_NODE_N_SWARM = 503,
   ERR_NO_TASK = 404,
+}
+
+export interface TaskError {
+  code: TaskErrorCode;
+  message: string;
 }
 
 @Injectable()
@@ -42,7 +47,10 @@ export class TaskService {
           return tasks;
         }),
         catchError((err: HttpErrorResponse) => {
-          return ErrorObservable.create(<TaskError>err.status);
+          return ErrorObservable.create({
+            code: <TaskErrorCode>err.status,
+            message: err.error['message'],
+          });
         })
       );
   }
@@ -64,7 +72,10 @@ export class TaskService {
           return x;
         }),
         catchError((err: HttpErrorResponse) => {
-          return ErrorObservable.create(<TaskError>err.status);
+          return ErrorObservable.create({
+            code: <TaskErrorCode>err.status,
+            message: err.error['message'],
+          });
         })
       );
   }
@@ -85,7 +96,10 @@ export class TaskService {
           return x;
         }),
         catchError((err: HttpErrorResponse) => {
-          return ErrorObservable.create(<TaskError>err.status);
+          return ErrorObservable.create({
+            code: <TaskErrorCode>err.status,
+            message: err.error['message'],
+          });
         })
       );
   }

--- a/src/app/services/user-management/user.service.ts
+++ b/src/app/services/user-management/user.service.ts
@@ -15,7 +15,6 @@ export enum UserStatusCode {
   REQUEST_ERR_SERVER = 500,
 }
 
-
 export interface UserError {
   code: UserStatusCode;
   message: string;
@@ -77,9 +76,9 @@ export class UserService {
             return ErrorObservable.create({
               code: <UserStatusCode>err.status,
               message: err.error['message'],
+            });
           }
         );
-      });
     });
   }
 

--- a/src/app/services/user-management/user.service.ts
+++ b/src/app/services/user-management/user.service.ts
@@ -46,40 +46,20 @@ export class UserService {
     });
   }
 
-  // createUser(username: string, password: string): Observable<string> {
-  //   return this.httpClient
-  //     .post(this.userEndpoint, { username: username, password: password })
-  //     .pipe(
-  //       map((x) => {
-  //         const observer = new Observable<UserStatusCode>();
-  //         return observer;
-  //       }),
-  //       catchError((err: HttpErrorResponse) => {
-  //         return ErrorObservable.create({
-  //           code: <UserStatusCode>err.status,
-  //           message: err.error['message'],
-  //         });
-  //    })
-  //   );
-  // }
-
   createUser(username: string, password: string): Observable<UserStatusCode> {
-    return new Observable<UserStatusCode>((observer) => {
-      this.httpClient
-        .post(this.userEndpoint, { username: username, password: password })
-        .subscribe(
-          (body) => {
-            observer.next(UserStatusCode.REQUEST_OK);
-          },
-          (err: HttpErrorResponse) => {
-            console.error(err);
-            return ErrorObservable.create({
-              code: <UserStatusCode>err.status,
-              message: err.error['message'],
-            });
-          }
-        );
-    });
+    return this.httpClient
+      .post(this.userEndpoint, { username: username, password: password })
+      .pipe(
+        map((x) => {
+          return UserStatusCode.REQUEST_OK;
+        }),
+        catchError((err: HttpErrorResponse) => {
+          return ErrorObservable.create({
+            code: err.status,
+            message: 'stub',
+          });
+        })
+      );
   }
 
   // TODO(egeldenhuys): Update using model

--- a/src/app/services/user-management/user.service.ts
+++ b/src/app/services/user-management/user.service.ts
@@ -8,7 +8,7 @@ import { User } from '../../models/user-management/user.model';
 import { ConfigurationService } from '../configuration/configuration.service';
 import { map, catchError } from 'rxjs/operators';
 
-export enum UserStatusCode {
+export enum UserErrorCode {
   REQUEST_OK = 200,
   CREATE_ERR_EXISTS = 409,
   REQUEST_ERR_NOT_FOUND = 404,
@@ -16,7 +16,7 @@ export enum UserStatusCode {
 }
 
 export interface UserError {
-  code: UserStatusCode;
+  code: UserErrorCode;
   message: string;
 }
 
@@ -52,7 +52,7 @@ export class UserService {
       .pipe(
         map((x) => {
           return ErrorObservable.create({
-            code: UserStatusCode.REQUEST_OK,
+            code: UserErrorCode.REQUEST_OK,
             message: 'stub',
           });
         }),
@@ -73,7 +73,7 @@ export class UserService {
         .subscribe(
           (body) => {
             observer.next({
-              code: UserStatusCode.REQUEST_OK,
+              code: UserErrorCode.REQUEST_OK,
               message: 'stub',
             });
           },
@@ -81,12 +81,12 @@ export class UserService {
             console.error(err);
             if (err.status === 404) {
               observer.error({
-                code: UserStatusCode.REQUEST_ERR_NOT_FOUND,
+                code: UserErrorCode.REQUEST_ERR_NOT_FOUND,
                 message: 'stub',
               });
             } else {
               observer.error({
-                code: UserStatusCode.REQUEST_ERR_NOT_FOUND,
+                code: UserErrorCode.REQUEST_ERR_NOT_FOUND,
                 message: 'stub',
               });
             }
@@ -96,18 +96,18 @@ export class UserService {
   }
 
   deleteUser(username: string) {
-    return new Observable<UserStatusCode>((observer) => {
+    return new Observable<UserErrorCode>((observer) => {
       this.httpClient.delete(this.userEndpoint + '/' + username).subscribe(
         (body) => {
-          observer.next(UserStatusCode.REQUEST_OK);
+          observer.next(UserErrorCode.REQUEST_OK);
         },
         (err: HttpErrorResponse) => {
           console.error(err);
 
           if (err.status === 404) {
-            observer.error(UserStatusCode.REQUEST_ERR_NOT_FOUND);
+            observer.error(UserErrorCode.REQUEST_ERR_NOT_FOUND);
           } else {
-            observer.error(UserStatusCode.REQUEST_ERR_SERVER);
+            observer.error(UserErrorCode.REQUEST_ERR_SERVER);
           }
         }
       );

--- a/src/app/services/user-management/user.service.ts
+++ b/src/app/services/user-management/user.service.ts
@@ -46,12 +46,15 @@ export class UserService {
     });
   }
 
-  createUser(username: string, password: string): Observable<UserStatusCode> {
+  createUser(username: string, password: string): Observable<UserError> {
     return this.httpClient
       .post(this.userEndpoint, { username: username, password: password })
       .pipe(
         map((x) => {
-          return UserStatusCode.REQUEST_OK;
+          return ErrorObservable.create({
+            code: UserStatusCode.REQUEST_OK,
+            message: 'stub',
+          });
         }),
         catchError((err: HttpErrorResponse) => {
           return ErrorObservable.create({
@@ -64,19 +67,28 @@ export class UserService {
 
   // TODO(egeldenhuys): Update using model
   updateUser(username: string, password: string) {
-    return new Observable<UserStatusCode>((observer) => {
+    return new Observable<UserError>((observer) => {
       this.httpClient
         .put(this.userEndpoint + '/' + username, { password: password })
         .subscribe(
           (body) => {
-            observer.next(UserStatusCode.REQUEST_OK);
+            observer.next({
+              code: UserStatusCode.REQUEST_OK,
+              message: 'stub',
+            });
           },
           (err: HttpErrorResponse) => {
             console.error(err);
             if (err.status === 404) {
-              observer.error(UserStatusCode.REQUEST_ERR_NOT_FOUND);
+              observer.error({
+                code: UserStatusCode.REQUEST_ERR_NOT_FOUND,
+                message: 'stub',
+              });
             } else {
-              observer.error(UserStatusCode.REQUEST_ERR_SERVER);
+              observer.error({
+                code: UserStatusCode.REQUEST_ERR_NOT_FOUND,
+                message: 'stub',
+              });
             }
           }
         );

--- a/src/app/services/volume/volume.service.ts
+++ b/src/app/services/volume/volume.service.ts
@@ -13,7 +13,7 @@ import { catchError, map } from 'rxjs/operators';
 import { ErrorObservable } from 'rxjs/observable/ErrorObservable';
 import { Volume } from '../../models/volume/volume.model';
 import { ConfigurationService } from '../../services/configuration/configuration.service';
-enum VolumeErrorCode {
+enum Volumecode {
   ERR_STREAM = 101,
   ERR_OK = 200,
   ERR_OK_DELETED = 204,
@@ -24,8 +24,8 @@ enum VolumeErrorCode {
 }
 
 export interface VolumeError {
-  ErrorCode: VolumeErrorCode;
-  ErrorMessage: string;
+  code: Volumecode;
+  message: string;
 }
 
 @Injectable()
@@ -48,8 +48,8 @@ export class VolumeService {
         }),
         catchError((err: HttpErrorResponse) => {
           return ErrorObservable.create({
-            ErrorCode: <VolumeErrorCode>err.status,
-            ErrorMessage: err.error['message'],
+            code: <Volumecode>err.status,
+            message: err.error['message'],
           });
         })
       );
@@ -70,8 +70,8 @@ export class VolumeService {
         }),
         catchError((err: HttpErrorResponse) => {
           return ErrorObservable.create({
-            ErrorCode: <VolumeErrorCode>err.status,
-            ErrorMessage: err.error['message'],
+            code: <Volumecode>err.status,
+            message: err.error['message'],
           });
         })
       );
@@ -96,8 +96,8 @@ export class VolumeService {
         }),
         catchError((err: HttpErrorResponse) => {
           return ErrorObservable.create({
-            ErrorCode: <VolumeErrorCode>err.status,
-            ErrorMessage: err.error['message'],
+            code: <Volumecode>err.status,
+            message: err.error['message'],
           });
         })
       );
@@ -119,8 +119,8 @@ export class VolumeService {
         }),
         catchError((err: HttpErrorResponse) => {
           return ErrorObservable.create({
-            ErrorCode: <VolumeErrorCode>err.status,
-            ErrorMessage: err.error['message'],
+            code: <Volumecode>err.status,
+            message: err.error['message'],
           });
         })
       );
@@ -147,8 +147,8 @@ export class VolumeService {
         }),
         catchError((err: HttpErrorResponse) => {
           return ErrorObservable.create({
-            ErrorCode: <VolumeErrorCode>err.status,
-            ErrorMessage: err.error['message'],
+            code: <Volumecode>err.status,
+            message: err.error['message'],
           });
         })
       );
@@ -169,8 +169,8 @@ export class VolumeService {
         }),
         catchError((err: HttpErrorResponse) => {
           return ErrorObservable.create({
-            ErrorCode: <VolumeErrorCode>err.status,
-            ErrorMessage: err.error['message'],
+            code: <Volumecode>err.status,
+            message: err.error['message'],
           });
         })
       );

--- a/src/app/services/volume/volume.service.ts
+++ b/src/app/services/volume/volume.service.ts
@@ -23,14 +23,9 @@ enum VolumeErrorCode {
   ERR_SERVER = 500,
 }
 
-export class VolumeError {
+export interface VolumeError {
   ErrorCode: VolumeErrorCode;
   ErrorMessage: string;
-
-  constructor(code: VolumeErrorCode, message: string) {
-    this.ErrorCode = code;
-    this.ErrorMessage = message;
-  }
 }
 
 @Injectable()
@@ -52,9 +47,10 @@ export class VolumeService {
           return <Volume[]>x['Volumes'];
         }),
         catchError((err: HttpErrorResponse) => {
-          return ErrorObservable.create(
-            new VolumeError(<VolumeErrorCode>err.status, 'stub')
-          );
+          return ErrorObservable.create({
+            ErrorCode: <VolumeErrorCode>err.status,
+            ErrorMessage: err.error['message'],
+          });
         })
       );
   }
@@ -73,9 +69,10 @@ export class VolumeService {
           return x['Warnings'];
         }),
         catchError((err: HttpErrorResponse) => {
-          return ErrorObservable.create(
-            new VolumeError(<VolumeErrorCode>err.status, err.error['message'])
-          );
+          return ErrorObservable.create({
+            ErrorCode: <VolumeErrorCode>err.status,
+            ErrorMessage: err.error['message'],
+          });
         })
       );
   }
@@ -98,9 +95,10 @@ export class VolumeService {
           return <Volume>x;
         }),
         catchError((err: HttpErrorResponse) => {
-          return ErrorObservable.create(
-            new VolumeError(<VolumeErrorCode>err.status, err.error['message'])
-          );
+          return ErrorObservable.create({
+            ErrorCode: <VolumeErrorCode>err.status,
+            ErrorMessage: err.error['message'],
+          });
         })
       );
   }
@@ -120,9 +118,10 @@ export class VolumeService {
           return <Volume>x;
         }),
         catchError((err: HttpErrorResponse) => {
-          return ErrorObservable.create(
-            new VolumeError(<VolumeErrorCode>err.status, err.error['message'])
-          );
+          return ErrorObservable.create({
+            ErrorCode: <VolumeErrorCode>err.status,
+            ErrorMessage: err.error['message'],
+          });
         })
       );
   }
@@ -147,9 +146,10 @@ export class VolumeService {
           return x;
         }),
         catchError((err: HttpErrorResponse) => {
-          return ErrorObservable.create(
-            new VolumeError(<VolumeErrorCode>err.status, err.error['message'])
-          );
+          return ErrorObservable.create({
+            ErrorCode: <VolumeErrorCode>err.status,
+            ErrorMessage: err.error['message'],
+          });
         })
       );
   }
@@ -168,9 +168,10 @@ export class VolumeService {
           return x;
         }),
         catchError((err: HttpErrorResponse) => {
-          return ErrorObservable.create(
-            new VolumeError(<VolumeErrorCode>err.status, err.error['message'])
-          );
+          return ErrorObservable.create({
+            ErrorCode: <VolumeErrorCode>err.status,
+            ErrorMessage: err.error['message'],
+          });
         })
       );
   }

--- a/src/app/services/volume/volume.service.ts
+++ b/src/app/services/volume/volume.service.ts
@@ -13,8 +13,7 @@ import { catchError, map } from 'rxjs/operators';
 import { ErrorObservable } from 'rxjs/observable/ErrorObservable';
 import { Volume } from '../../models/volume/volume.model';
 import { ConfigurationService } from '../../services/configuration/configuration.service';
-
-enum VolumeError {
+enum VolumeErrorCode {
   ERR_STREAM = 101,
   ERR_OK = 200,
   ERR_OK_DELETED = 204,
@@ -22,6 +21,16 @@ enum VolumeError {
   ERR_NO_VOLUME = 404,
   ERR_VOLUME_IS_USE = 409,
   ERR_SERVER = 500,
+}
+
+export class VolumeError {
+  ErrorCode: VolumeErrorCode;
+  ErrorMessage: string;
+
+  constructor(code: VolumeErrorCode, message: string) {
+    this.ErrorCode = code;
+    this.ErrorMessage = message;
+  }
 }
 
 @Injectable()
@@ -43,7 +52,9 @@ export class VolumeService {
           return <Volume[]>x['Volumes'];
         }),
         catchError((err: HttpErrorResponse) => {
-          return ErrorObservable.create(<VolumeError>err.status);
+          return ErrorObservable.create(
+            new VolumeError(<VolumeErrorCode>err.status, 'stub')
+          );
         })
       );
   }
@@ -62,7 +73,9 @@ export class VolumeService {
           return x['Warnings'];
         }),
         catchError((err: HttpErrorResponse) => {
-          return ErrorObservable.create(<VolumeError>err.status);
+          return ErrorObservable.create(
+            new VolumeError(<VolumeErrorCode>err.status, err.error['message'])
+          );
         })
       );
   }
@@ -85,7 +98,9 @@ export class VolumeService {
           return <Volume>x;
         }),
         catchError((err: HttpErrorResponse) => {
-          return ErrorObservable.create(<VolumeError>err.status);
+          return ErrorObservable.create(
+            new VolumeError(<VolumeErrorCode>err.status, err.error['message'])
+          );
         })
       );
   }
@@ -105,7 +120,9 @@ export class VolumeService {
           return <Volume>x;
         }),
         catchError((err: HttpErrorResponse) => {
-          return ErrorObservable.create(<VolumeError>err.status);
+          return ErrorObservable.create(
+            new VolumeError(<VolumeErrorCode>err.status, err.error['message'])
+          );
         })
       );
   }
@@ -130,7 +147,9 @@ export class VolumeService {
           return x;
         }),
         catchError((err: HttpErrorResponse) => {
-          return ErrorObservable.create(<VolumeError>err.status);
+          return ErrorObservable.create(
+            new VolumeError(<VolumeErrorCode>err.status, err.error['message'])
+          );
         })
       );
   }
@@ -149,7 +168,9 @@ export class VolumeService {
           return x;
         }),
         catchError((err: HttpErrorResponse) => {
-          return ErrorObservable.create(<VolumeError>err.status);
+          return ErrorObservable.create(
+            new VolumeError(<VolumeErrorCode>err.status, err.error['message'])
+          );
         })
       );
   }

--- a/src/app/services/volume/volume.service.ts
+++ b/src/app/services/volume/volume.service.ts
@@ -13,7 +13,7 @@ import { catchError, map } from 'rxjs/operators';
 import { ErrorObservable } from 'rxjs/observable/ErrorObservable';
 import { Volume } from '../../models/volume/volume.model';
 import { ConfigurationService } from '../../services/configuration/configuration.service';
-enum Volumecode {
+enum VolumeErrorCode {
   ERR_STREAM = 101,
   ERR_OK = 200,
   ERR_OK_DELETED = 204,
@@ -24,7 +24,7 @@ enum Volumecode {
 }
 
 export interface VolumeError {
-  code: Volumecode;
+  code: VolumeErrorCode;
   message: string;
 }
 
@@ -48,7 +48,7 @@ export class VolumeService {
         }),
         catchError((err: HttpErrorResponse) => {
           return ErrorObservable.create({
-            code: <Volumecode>err.status,
+            code: <VolumeErrorCode>err.status,
             message: err.error['message'],
           });
         })
@@ -70,7 +70,7 @@ export class VolumeService {
         }),
         catchError((err: HttpErrorResponse) => {
           return ErrorObservable.create({
-            code: <Volumecode>err.status,
+            code: <VolumeErrorCode>err.status,
             message: err.error['message'],
           });
         })
@@ -96,7 +96,7 @@ export class VolumeService {
         }),
         catchError((err: HttpErrorResponse) => {
           return ErrorObservable.create({
-            code: <Volumecode>err.status,
+            code: <VolumeErrorCode>err.status,
             message: err.error['message'],
           });
         })
@@ -119,7 +119,7 @@ export class VolumeService {
         }),
         catchError((err: HttpErrorResponse) => {
           return ErrorObservable.create({
-            code: <Volumecode>err.status,
+            code: <VolumeErrorCode>err.status,
             message: err.error['message'],
           });
         })
@@ -147,7 +147,7 @@ export class VolumeService {
         }),
         catchError((err: HttpErrorResponse) => {
           return ErrorObservable.create({
-            code: <Volumecode>err.status,
+            code: <VolumeErrorCode>err.status,
             message: err.error['message'],
           });
         })
@@ -169,7 +169,7 @@ export class VolumeService {
         }),
         catchError((err: HttpErrorResponse) => {
           return ErrorObservable.create({
-            code: <Volumecode>err.status,
+            code: <VolumeErrorCode>err.status,
             message: err.error['message'],
           });
         })


### PR DESCRIPTION
All services dealing with REST backends now return an interface of the following form.

````ts
{
    code: int,   // Usually an enum
    message: string,
}
````
This should make displaying informative error messages to the user in most cases; See the dummy code as an example.

````ts
ContainerService.getContainers().subscribe((containers) => console.table(containers), (err: ContainerError) => {
        console.log("The message is: " + err.message);
        // err.code is for internal use.
});
````