### PR TITLE
Revert Task Endpoint

### DIFF
--- a/src/app/services/task/task.service.ts
+++ b/src/app/services/task/task.service.ts
@@ -34,8 +34,9 @@ export class TaskService {
    * @returns {Observable<Task[]>}
    */
   public getTasks(): Observable<Task[]> {
+    // TODO(egeldenhuys): The `/tasks` endpoint has not been tested with query parameters
     return this.http
-      .get(this.config.getAPIHostname() + '/docker/tasks', {
+      .get(this.config.getAPIHostname() + '/tasks', {
         responseType: 'json',
       })
       .pipe(


### PR DESCRIPTION
The `/tasks` endpoint should behave the same as `/docker/tasks`, except that it also returns a `NodeHostname` attribute for each task. This is used in the datatables.

The endpoint was changed to `/docker/tasks` in an earlier PR, this PR reverts that change.
If anything breaks with the `/tasks` endpoint please let me know.