### PR TITLE
Clean up docker headers from logs

### DIFF
--- a/src/app/pages/services/service-logs/service-logs.component.ts
+++ b/src/app/pages/services/service-logs/service-logs.component.ts
@@ -48,9 +48,12 @@ export class ServiceLogsComponent implements OnInit {
     this.serviceService.getServiceLog(this.serviceID).subscribe(
       (service) => {
         this.Log = service;
+        // this.Log = this.Log.slice(8);
 
         if (this.Log.length === 0) {
           this.Log = 'The service ' + this.serviceName + ' returned no log';
+        } else {
+          this.Log = this.parseLog(this.Log);
         }
         this.isLoadedLog = true;
       },
@@ -58,5 +61,17 @@ export class ServiceLogsComponent implements OnInit {
         this.toastr.error(err.message, 'An error occured');
       }
     );
+  }
+
+  parseLog(log) {
+    const logArray = log.split('\n');
+    let ret = '';
+
+    logArray.forEach(element => {
+      element = element.slice(8);
+      ret = ret + element + '\n';
+    });
+
+    return ret;
   }
 }


### PR DESCRIPTION
This closes #171 . It removes the unicode headers add by docker which created weird characters in the logs.
![logs](https://user-images.githubusercontent.com/36559294/46835991-0ebcea00-cdb0-11e8-9104-0cbbf964d1fb.jpeg)
