### PR TITLE
Play With Docker Support

### DIFF
--- a/src/app/pages/webhooks/webhooks-create/webhook-create.component.spec.ts
+++ b/src/app/pages/webhooks/webhooks-create/webhook-create.component.spec.ts
@@ -26,7 +26,7 @@ describe('WebhookCreateComponent', () => {
         RouterTestingModule,
         FormsModule,
         ToastrModule.forRoot(),
-        AceEditorModule
+        AceEditorModule,
       ],
       providers: [
         VolumeService,

--- a/src/app/pages/webhooks/webhooks-create/webhook-create.component.ts
+++ b/src/app/pages/webhooks/webhooks-create/webhook-create.component.ts
@@ -31,25 +31,33 @@ export class WebhookCreateComponent implements OnInit, AfterViewInit {
   public nodes: boolean;
   public default_text = '(json) => { return json;}';
   public text: string = this.default_text;
-  public triggerTypes = ['Volumes', 'Network', 'Service', 'Node', 'Image', 'Daemon', 'Secret', 'Config'];
+  public triggerTypes = [
+    'Volumes',
+    'Network',
+    'Service',
+    'Node',
+    'Image',
+    'Daemon',
+    'Secret',
+    'Config',
+  ];
 
   webhookForm: FormGroup = this.fb.group({
     Name: ['', Validators.required],
     url: ['', Validators.required],
     Labels: new FormGroup(this.initTriggers()),
-    Editor: ['']
+    Editor: [''],
   });
 
   constructor(
     private wh: WebhookService,
     private toastr: ToastrService,
     private router: Router,
-    private fb: FormBuilder,
+    private fb: FormBuilder
   ) {
     this.name = '';
     this.url = '';
   }
-
 
   ngAfterViewInit() {
     this.editor.setTheme('dreamweaver');
@@ -61,8 +69,6 @@ export class WebhookCreateComponent implements OnInit, AfterViewInit {
 
   ngOnInit() {}
 
-
-
   initLabels() {
     return this.fb.group({
       Name: ['', Validators.required],
@@ -71,7 +77,7 @@ export class WebhookCreateComponent implements OnInit, AfterViewInit {
 
   initTriggers() {
     const fGroup = {};
-    this.triggerTypes.forEach(element => {
+    this.triggerTypes.forEach((element) => {
       fGroup[element] = new FormControl(false);
     });
 
@@ -105,10 +111,7 @@ export class WebhookCreateComponent implements OnInit, AfterViewInit {
     let temp = '{';
 
     while (i < this.Labels.length) {
-      temp +=
-        '"' +
-        this.Labels.at(i).get('Name').value +
-        '":"';
+      temp += '"' + this.Labels.at(i).get('Name').value + '":"';
       i++;
     }
 
@@ -158,7 +161,7 @@ export class WebhookCreateComponent implements OnInit, AfterViewInit {
     if (this.text !== this.default_text) {
       webby.modifier = btoa(this.text);
     }
-    console.log({webby});
+    console.log({ webby });
     this.wh.createWebhook(webby).subscribe(
       (result: WebhookError) => {
         this.toastr.success(
@@ -174,13 +177,14 @@ export class WebhookCreateComponent implements OnInit, AfterViewInit {
   }
 
   public hasNameAndURL() {
-    if (this.webhookForm.get('Name').value > 0 && this.webhookForm.get('url').value > 0) {
+    if (
+      this.webhookForm.get('Name').value > 0 &&
+      this.webhookForm.get('url').value > 0
+    ) {
       return true;
     }
     return false;
   }
 
   onChange() {}
-
-
 }

--- a/src/app/services/configuration/configuration.service.ts
+++ b/src/app/services/configuration/configuration.service.ts
@@ -41,56 +41,80 @@ export class ConfigurationService {
    * by the router.
    */
   public fetchAPIHostname() {
-    this.http.get('/config', { responseType: 'json' }).subscribe(
-      (data: Object) => {
-        // "Reload" the active path to enable the new Docks address
-        // This is required to reload any components that have
-        // requested a null address
-        if (this.tokenStorage.getToken(docksApiAddressKey) === null) {
-          const url = this.router.url;
+    const currentUrl: string = window.location.href;
 
-          this.router
-            .navigate(['refresh'])
-            .then((val1: boolean) => {
-              this.router
-                .navigate([url])
-                .then((val2: boolean) => {
-                  console.log(
-                    'Fixed null Docks API address: ' + (val1 && val2)
-                  );
-                })
-                .catch((err2: any) => {
-                  console.error('Error navigating to ' + url);
-                  console.error(err2);
-                });
-            })
-            .catch((err1: any) => {
-              console.error('Error while navigating to "/refresh"');
-              console.error(err1);
-            });
-        }
+    // Need to match the following url and patch the port
+    // http://ip172-18-0-8-bf132dc9cs9g00ffpcog-4200.direct.labs.play-with-docker.com/login
 
-        this.apiHostname = data['docksApiAddress'];
-        this.tokenStorage.saveToken(docksApiAddressKey, this.apiHostname);
-      },
+    if (currentUrl.includes('direct.labs.play-with-docker.com')) {
+      currentUrl.replace('4200.direct', '8080.direct');
 
-      (error: any) => {
-        const errorString: string = error.toString();
-        const errorParts: string[] = errorString.split('\n');
-
-        // This error appears to only occur when executing using `ng test`
-        // TODO(egeldenhuys): Fix whatever is causing this error
-        if (
-          errorParts[0] === 'TypeError: _this.handler.handle is not a function'
-        ) {
-          console.warn(
-            'ConfigurationService::fetchAPIHostname(): Suppressed "TypeError: _this.handler.handle is not a function"'
-          );
-        } else {
-          console.error('Error while loading Docks API addess from /config');
-          console.error(error);
-        }
+      if (this.tokenStorage.getToken(docksApiAddressKey) === null) {
+        this.refreshPage();
       }
+
+      console.log('Setting Docks API address to ', currentUrl);
+      this.apiHostname = currentUrl;
+      this.tokenStorage.saveToken(docksApiAddressKey, this.apiHostname);
+    } else {
+      this.http.get('/config', { responseType: 'json' }).subscribe(
+        (data: Object) => {
+          // "Reload" the active path to enable the new Docks address
+          // This is required to reload any components that have
+          // requested a null address
+          if (this.tokenStorage.getToken(docksApiAddressKey) === null) {
+            this.refreshPage();
+          }
+
+          console.log('Setting Docks API address to ', data['docksApiAddress']);
+          this.apiHostname = data['docksApiAddress'];
+          this.tokenStorage.saveToken(docksApiAddressKey, this.apiHostname);
+        },
+
+        (error: any) => {
+          const errorString: string = error.toString();
+          const errorParts: string[] = errorString.split('\n');
+
+          // This error appears to only occur when executing using `ng test`
+          // TODO(egeldenhuys): Fix whatever is causing this error
+          if (
+            errorParts[0] ===
+            'TypeError: _this.handler.handle is not a function'
+          ) {
+            console.warn(
+              'ConfigurationService::fetchAPIHostname(): Suppressed "TypeError: _this.handler.handle is not a function"'
+            );
+          } else {
+            console.error('Error while loading Docks API address from /config');
+            console.error(error);
+          }
+        }
+      );
+    }
+  }
+
+  public refreshPage() {
+    console.log(
+      'Refreshing page to trigger possible failed requests to Docks API'
     );
+
+    const url = this.router.url;
+    this.router
+      .navigate(['refresh'])
+      .then((val1: boolean) => {
+        this.router
+          .navigate([url])
+          .then((val2: boolean) => {
+            console.log('Fixed null Docks API address');
+          })
+          .catch((err2: any) => {
+            console.error('Error navigating to ' + url);
+            console.error(err2);
+          });
+      })
+      .catch((err1: any) => {
+        console.error('Error while navigating to "/refresh"');
+        console.error(err1);
+      });
   }
 }

--- a/src/app/services/configuration/configuration.service.ts
+++ b/src/app/services/configuration/configuration.service.ts
@@ -48,6 +48,7 @@ export class ConfigurationService {
     // NOTE: API port is hardcoded here
 
     if (currentUrl.includes('direct.labs.play-with-docker.com')) {
+      currentUrl = currentUrl.split('/')[0];
       currentUrl = currentUrl.replace('4200.direct', '8080.direct');
 
       if (this.tokenStorage.getToken(docksApiAddressKey) === null) {

--- a/src/app/services/configuration/configuration.service.ts
+++ b/src/app/services/configuration/configuration.service.ts
@@ -41,13 +41,14 @@ export class ConfigurationService {
    * by the router.
    */
   public fetchAPIHostname() {
-    const currentUrl: string = window.location.href;
+    let currentUrl: string = window.location.href;
 
     // Need to match the following url and patch the port
     // http://ip172-18-0-8-bf132dc9cs9g00ffpcog-4200.direct.labs.play-with-docker.com/login
+    // NOTE: API port is hardcoded here
 
     if (currentUrl.includes('direct.labs.play-with-docker.com')) {
-      currentUrl.replace('4200.direct', '8080.direct');
+      currentUrl = currentUrl.replace('4200.direct', '8080.direct');
 
       if (this.tokenStorage.getToken(docksApiAddressKey) === null) {
         this.refreshPage();

--- a/src/app/services/configuration/configuration.service.ts
+++ b/src/app/services/configuration/configuration.service.ts
@@ -48,7 +48,8 @@ export class ConfigurationService {
     // NOTE: API port is hardcoded here
 
     if (currentUrl.includes('direct.labs.play-with-docker.com')) {
-      currentUrl = currentUrl.split('/')[0];
+      const urlParts: string[] = currentUrl.split('/');
+      currentUrl = urlParts[0] + '//' + urlParts[2];
       currentUrl = currentUrl.replace('4200.direct', '8080.direct');
 
       if (this.tokenStorage.getToken(docksApiAddressKey) === null) {


### PR DESCRIPTION
Closes #204 

If the URL contains `labs.play-with-docker.com` then the API address will be set to the same address as the UI, but with a different port.
Example:
- UI: `http://ip172-18-0-13-bf13t0eac3u000ahk0dg-4200.direct.labs.play-with-docker.com/login`
- API: `http://ip172-18-0-13-bf13t0eac3u000ahk0dg-8080.direct.labs.play-with-docker.com/login`

NOTE: Port 8080 is hard coded since there is no intuitive or reliable method to retrieve it from an external source.

### Demo
[![Try in PWD](https://cdn.rawgit.com/play-with-docker/stacks/cff22438/assets/images/button.png)](http://play-with-docker.com?stack=https://gist.githubusercontent.com/egeldenhuys/13d12a28bcba18b66937e1758528d7ab/raw/1458674813b8a314365e66b98f559bef03cc33de/docker-compose.yml)

View the UI by clicking on the `4200` port link. If your screen does not look similar to the screenshot, reload the page.

![screenshot_2018-10-13 docker playground](https://user-images.githubusercontent.com/5778739/46908986-86635400-cf2b-11e8-8f7a-f16375b827ab.png)
